### PR TITLE
Fix an indefinite hang on active map reset

### DIFF
--- a/Examples/Stereo-Inertial/realsense_websocket_client.cpp
+++ b/Examples/Stereo-Inertial/realsense_websocket_client.cpp
@@ -77,7 +77,7 @@ int main(int argc, char **argv) {
                 }
             }
             else if(msg->type == ix::WebSocketMessageType::Open) {
-                std::cout << "Connection established" << std::endl;
+                std::cout << "Connected to the Realsense websocket" << std::endl;
                 connected = true;
                 webSocket.send("gimme");
             }

--- a/scripts/janitorAgain.py
+++ b/scripts/janitorAgain.py
@@ -10,57 +10,7 @@ with open('data.txt') as f:
 # data_acc = np.array([[float(y) for y in re.sub(' +', ' ',x[5:].strip()).split(' ')] for x in lines if pat_acc.match(x)])
 data_bias = np.array([[float(y) for y in re.sub(' +', ' ',x[4:].strip()).split(' ')[:3]] for x in lines if pat_bias.match(x)])
 
-# data_mag_acc_bias = np.sqrt(data_bias[:,0]**2 + data_bias[:,1]**2 + data_bias[:,2]**2)
-# data_mag_acc_imu = np.sqrt(data_acc[:,0]**2 + data_acc[:,1]**2 + data_acc[:,2]**2)
+plt.plot(data_bias)
 
-# diff = np.subtract(data_bias, data_acc)
-# mag = np.sqrt(diff[:,0]**2 + diff[:,1]**2 + diff[:,2]**2)
-
-# data_mag_real_acc_imu = np.sqrt(data_real_acc_imu[:,0]**2 + data_real_acc_imu[:,1]**2 + data_real_acc_imu[:,2]**2)
-
-### FOR LOST DETECTION TESTING
-# last_val = 0
-# longest_streak = 0
-# longest_streak_index = 0
-# active_streak = 0
-# index = -1
-# threshold = 0.01
-# for i in data_bias[:,2]:
-#     if i*last_val > 0:
-#         if abs(i) > threshold:
-#             active_streak += 1
-#     else:
-#         if active_streak > longest_streak:
-#             longest_streak = active_streak
-#             longest_streak_index = index
-#         if active_streak >= 10:
-#             print("Streak of", active_streak, "@ index", index)
-#         active_streak = 0
-        
-#     last_val = i
-#     index += 1
-# print("Longest Streak is", longest_streak, "@ index", longest_streak_index)
-
-# positions = np.zeros(len(data_bias[:,2]))
-# positions[0] = data_bias[0,2]
-# for i in range(1,len(data_bias[:,2])):
-#     positions[i] = positions[i-1] + data_bias[i,2]
-plt.plot(data_bias[:,:2])
-
-# smooth_x = np.zeros(len(data_bias[:,0]))
-# smooth_x[0] = data_bias[0,0]
-# smooth_x[1] = data_bias[1,0]
-# for i in range(2,len(smooth_x)):
-#     smooth_x[i] = (data_bias[i,0] + smooth_x[i-1] + smooth_x[i-2])/3
-
-# # plt.plot(data_acc)
-# plt.plot(smooth_x)
-# plt.plot(positions)
-
-
-# plt.plot(diff)
-# plt.plot(data_mag_acc_imu)
-# plt.legend(["bias_mag", "acc_mag"])
-plt.legend(["x", "y"])
-# plt.legend(["ax", "ay", "az", "bax","bay","baz"])
+plt.legend(["x", "y", "z"])
 plt.show()

--- a/src/Atlas.cc
+++ b/src/Atlas.cc
@@ -40,16 +40,16 @@ Atlas::~Atlas() {}
 
 void Atlas::CreateNewMap() {
   std::unique_lock<std::recursive_mutex> lock(mMutexAtlas);
-  std::cout << "Creation of new std::map with id: " << Map::nNextId << std::endl;
+  std::cout << "Creation of new Map with id: " << Map::nNextId << std::endl;
   if (mpCurrentMap) {
     //If it's not a new Atlas, and there aren't 0 KFs in the current map
     if (!mspMaps.empty() && mnLastInitKFidMap < mpCurrentMap->GetMaxKFid())
       // The map's init KF ID is one after the current map's maximum KF ID
       mnLastInitKFidMap = mpCurrentMap->GetMaxKFid() + 1;  
 
-    std::cout << "Stored std::map with ID: " << mpCurrentMap->GetId() << std::endl;
+    std::cout << "Stored Map with ID: " << mpCurrentMap->GetId() << std::endl;
   }
-  std::cout << "Creation of new std::map with last KF id: " << mnLastInitKFidMap << std::endl;
+  std::cout << "Creation of new Map with last KF id: " << mnLastInitKFidMap << std::endl;
 
   mpCurrentMap = std::make_shared<Map>(mnLastInitKFidMap);
   mspMaps.insert(mpCurrentMap);
@@ -57,7 +57,7 @@ void Atlas::CreateNewMap() {
 
 void Atlas::ChangeMap(std::shared_ptr<Map> pMap) {
   std::unique_lock<std::recursive_mutex> lock(mMutexAtlas);
-  std::cout << "Change to std::map with id: " << pMap->GetId() << std::endl;
+  std::cout << "Change to Map with id: " << pMap->GetId() << std::endl;
   mpCurrentMap = pMap;
 }
 

--- a/src/ExternalMapViewer.cc
+++ b/src/ExternalMapViewer.cc
@@ -22,7 +22,7 @@ ExternalMapViewer::ExternalMapViewer(const System_ptr& pSystem, const std::strin
     serverAddress(_serverAddress),
     serverPort(_serverPort),
     valuesPushed(false) {
-        std::cout << "Creating Thread in ExternalMapViewer" << std::endl;
+        std::cout << "Creating ExternalMapViewer thread" << std::endl;
         threadEMV = std::jthread(&ExternalMapViewer::run, this);
     }
 

--- a/src/LocalMapping.cc
+++ b/src/LocalMapping.cc
@@ -1210,7 +1210,7 @@ void LocalMapping::InitializeIMU(ImuInitializater::ImuInitType priorG, ImuInitia
     }
 
   // std::chrono::steady_clock::time_point t4 = std::chrono::steady_clock::now(); // UNUSED
-  Verbose::PrintMess("Global Bundle Adjustment started", Verbose::VERBOSITY_NORMAL);
+  Verbose::PrintMess("start Global Bundle Adjustment", Verbose::VERBOSITY_NORMAL);
     // if FullInertialBA isn't called, SLAM instantly gets lost
     // also bFIBA is always true
     // if (bFIBA) {
@@ -1227,7 +1227,7 @@ void LocalMapping::InitializeIMU(ImuInitializater::ImuInitType priorG, ImuInitia
 
   // std::chrono::steady_clock::time_point t5 = std::chrono::steady_clock::now(); // UNUSED
 
-    Verbose::PrintMess("Global Bundle Adjustment finished", Verbose::VERBOSITY_NORMAL);
+    Verbose::PrintMess("end Global Bundle Adjustment", Verbose::VERBOSITY_NORMAL);
 
     // Get Map Mutex
     std::scoped_lock<std::mutex> lock(mpAtlas->GetCurrentMap()->mMutexMapUpdate);

--- a/src/LoopClosing.cc
+++ b/src/LoopClosing.cc
@@ -765,9 +765,9 @@ bool LoopClosing::DetectCommonRegionsFromBoW(std::vector<KeyFrame*>& vpBowCand, 
     g2oScw = g2oBestScw;
     vpMPs = vpBestMapPoints;
     vpMatchedMPs = vpBestMatchedMapPoints;
-    if(nNumCoincidences >= 3){
-      std::cout << "Number of matches: " << nBestMatchesReproj << std::endl;
-    }
+    // if(nNumCoincidences >= 3){
+    //   std::cout << "Number of matches: " << nBestMatchesReproj << std::endl;
+    // }
 
     return nNumCoincidences >= 3;
   /* Everything down here does not change any state and is UNUSED
@@ -1046,7 +1046,7 @@ void LoopClosing::CorrectLoop() {
     mbFinishedGBA = false;
     mbStopGBA = false;
     mnCorrectionGBA = mnNumCorrection;
-    std::cout << "Creating Thread in LoopClosing::CorrectLoop()" << std::endl;
+    std::cout << "Creating CorrectLoop thread" << std::endl;
     mpThreadGBA = std::jthread(&LoopClosing::RunGlobalBundleAdjustment, this, pLoopMap, mpCurrentKF->mnId);
   }
 
@@ -1535,7 +1535,7 @@ void LoopClosing::MergeLocal() {
     mbRunningGBA = true;
     mbFinishedGBA = false;
     mbStopGBA = false;
-    std::cout << "Creating Thread in LoopClosing::MergeLocal()" << std::endl;
+    std::cout << "Creating MergeLocal thread" << std::endl;
     mpThreadGBA = std::jthread(&LoopClosing::RunGlobalBundleAdjustment, this, pMergeMap, mpCurrentKF->mnId);
   }
 

--- a/src/Optimizer/FullInertialBA.cc
+++ b/src/Optimizer/FullInertialBA.cc
@@ -124,8 +124,8 @@ void Optimizer::FullInertialBA(std::shared_ptr<Map> pMap, int its, const bool bF
     KeyFrame* pKFi = vpKFs[i];
 
     if (!pKFi->mPrevKF) {
-      Verbose::PrintMess("NOT INERTIAL LINK TO PREVIOUS FRAME!",
-                         Verbose::VERBOSITY_NORMAL);
+      if(pMap->GetOriginKF() != pKFi)
+        Verbose::PrintMess("NOT INERTIAL LINK TO PREVIOUS FRAME!", Verbose::VERBOSITY_NORMAL);
       continue;
     }
 
@@ -207,13 +207,10 @@ void Optimizer::FullInertialBA(std::shared_ptr<Map> pMap, int its, const bool bF
           optimizer.addEdge(ear);
         }
       } else
-        std::cout << pKFi->mnId << " or " << pKFi->mPrevKF->mnId << " no imu"
-             << std::endl;
+        std::cout << pKFi->mnId << " or " << pKFi->mPrevKF->mnId << " no imu" << std::endl;
     }
   }
-  std::cout << "Before bInit" << std::endl;
   if (bInit) {
-  std::cout << "In bInit" << std::endl;
     g2o::HyperGraph::Vertex* VG = optimizer.vertex(4 * maxKFid + 2);
     g2o::HyperGraph::Vertex* VA = optimizer.vertex(4 * maxKFid + 3);
 
@@ -233,7 +230,6 @@ void Optimizer::FullInertialBA(std::shared_ptr<Map> pMap, int its, const bool bF
     epg->setInformation(infoPriorG * Eigen::Matrix3d::Identity());
     optimizer.addEdge(epg);
   }
-  std::cout << "Done bInit" << std::endl;
 
   const float thHuberMono = sqrt(5.991);
   const float thHuberStereo = sqrt(7.815);
@@ -242,7 +238,6 @@ void Optimizer::FullInertialBA(std::shared_ptr<Map> pMap, int its, const bool bF
 
   std::vector<bool> vbNotIncludedMP(vpMPs.size(), false);
 
-  std::cout << "opt 6" << std::endl;
   for (size_t i = 0; i < vpMPs.size(); i++) {
     MapPoint* pMP = vpMPs[i];
     g2o::VertexSBAPointXYZ* vPoint = new g2o::VertexSBAPointXYZ();
@@ -257,28 +252,22 @@ void Optimizer::FullInertialBA(std::shared_ptr<Map> pMap, int its, const bool bF
     bool bAllFixed = true;
 
     // Set edges
-    // std::cout << "opt 8" << std::endl;
     for (std::map<KeyFrame*, std::tuple<int, int>>::const_iterator
              mit = observations.begin(),
              mend = observations.end();
          mit != mend; mit++) {
       KeyFrame* pKFi = mit->first;
-      // std::cout << "opt 81" << std::endl;
 
       if (pKFi->mnId > maxKFid){
-        // std::cout << "opt 811" << std::endl;
         continue;
       }
-      // std::cout << "opt 82" << std::endl;
 
       if (!pKFi->isBad()) {
-        // std::cout << "opt 821" << std::endl;
         const int leftIndex = std::get<0>(mit->second);
         cv::KeyPoint kpUn;
 
         if (leftIndex != -1 && pKFi->mvuRight[std::get<0>(mit->second)] < 0)  // Monocular observation
         {
-        // std::cout << "opt 822" << std::endl;
           kpUn = pKFi->mvKeysUn[leftIndex];
           Eigen::Matrix<double, 2, 1> obs;
           obs << kpUn.pt.x, kpUn.pt.y;
@@ -306,10 +295,8 @@ void Optimizer::FullInertialBA(std::shared_ptr<Map> pMap, int its, const bool bF
           optimizer.addEdge(e);
         } else if (leftIndex != -1 && pKFi->mvuRight[leftIndex] >= 0)  // stereo observation
         {
-          // std::cout << "opt 823" << std::endl;
           kpUn = pKFi->mvKeysUn[leftIndex];
           const float kp_ur = pKFi->mvuRight[leftIndex];
-          // std::cout << "opt 8231" << std::endl;
           Eigen::Matrix<double, 3, 1> obs;
           obs << kpUn.pt.x, kpUn.pt.y, kp_ur;
 
@@ -318,30 +305,25 @@ void Optimizer::FullInertialBA(std::shared_ptr<Map> pMap, int its, const bool bF
           g2o::OptimizableGraph::Vertex* VP =
               dynamic_cast<g2o::OptimizableGraph::Vertex*>(
                   optimizer.vertex(pKFi->mnId));
-          // std::cout << "opt 8232" << std::endl;
           if (bAllFixed)
             if (!VP->fixed()) bAllFixed = false;
 
           e->setVertex(0, dynamic_cast<g2o::OptimizableGraph::Vertex*>(
                               optimizer.vertex(id)));
-          // std::cout << "opt 8233" << std::endl;
           e->setVertex(1, VP);
           e->setMeasurement(obs);
           const float invSigma2 = pKFi->mvInvLevelSigma2[kpUn.octave];
 
           e->setInformation(Eigen::Matrix3d::Identity() * invSigma2);
-          // std::cout << "opt 8234" << std::endl;
 
           g2o::RobustKernelHuber* rk = new g2o::RobustKernelHuber;
           e->setRobustKernel(rk);
           rk->setDelta(thHuberStereo);
 
           optimizer.addEdge(e);
-          // std::cout << "opt 8235" << std::endl;
         }
 
         if (pKFi->mpCamera2) {  // Monocular right observation
-          std::cout << "opt 824 never" << std::endl;
           int rightIndex = std::get<1>(mit->second);
 
           if (rightIndex != -1 && rightIndex < static_cast<int>(pKFi->mvKeysRight.size())) {
@@ -374,25 +356,19 @@ void Optimizer::FullInertialBA(std::shared_ptr<Map> pMap, int its, const bool bF
           }
         }
       }
-      // std::cout << "opt 83" << std::endl;
     }
-    // std::cout << "opt 9" << std::endl;
     if (bAllFixed) {
       optimizer.removeVertex(vPoint);
       vbNotIncludedMP[i] = true;
     }
   }
-  std::cout << "opt 5" << std::endl;
 
   if (pbStopFlag)
     if (*pbStopFlag) return;
 
-  std::cout << "opt 4" << std::endl;
   optimizer.initializeOptimization();
-  std::cout << "opt 3" << std::endl;
   optimizer.optimize(its);
 
-  std::cout << "opt 2" << std::endl;
   // Recover optimized data
   // Keyframes
   for (size_t i = 0; i < vpKFs.size(); i++) {
@@ -439,7 +415,6 @@ void Optimizer::FullInertialBA(std::shared_ptr<Map> pMap, int its, const bool bF
       }
     }
   }
-  std::cout << "opt 1" << std::endl;
 
   // Points
   for (size_t i = 0; i < vpMPs.size(); i++) {
@@ -459,7 +434,6 @@ void Optimizer::FullInertialBA(std::shared_ptr<Map> pMap, int its, const bool bF
   }
 
   pMap->IncreaseChangeIndex();
-  std::cout << "End of opt" << std::endl;
 }
 
 

--- a/src/Optimizer/InertialOptimization.cc
+++ b/src/Optimizer/InertialOptimization.cc
@@ -49,7 +49,7 @@ void Optimizer::InertialOptimization(std::shared_ptr<Map> pMap, Eigen::Matrix3d&
                                      bool bFixedVel, bool bGauss, 
                                      ImuInitializater::ImuInitType priorG,
                                      ImuInitializater::ImuInitType priorA) {
-  Verbose::PrintMess("inertial optimization", Verbose::VERBOSITY_NORMAL);
+  Verbose::PrintMess("Starting inertial optimization", Verbose::VERBOSITY_NORMAL);
   int its = 200;
   long unsigned int maxKFid = pMap->GetMaxKFid();
   const std::vector<KeyFrame*> vpKFs = pMap->GetAllKeyFrames();
@@ -222,6 +222,7 @@ void Optimizer::InertialOptimization(std::shared_ptr<Map> pMap, Eigen::Matrix3d&
     } else
       pKFi->SetNewBias(b);
   }
+  Verbose::PrintMess("Inertial optimization complete", Verbose::VERBOSITY_NORMAL);
 }
 
 // used in LoopClosing

--- a/src/Optimizer/InertialOptimization.cc
+++ b/src/Optimizer/InertialOptimization.cc
@@ -49,7 +49,7 @@ void Optimizer::InertialOptimization(std::shared_ptr<Map> pMap, Eigen::Matrix3d&
                                      bool bFixedVel, bool bGauss, 
                                      ImuInitializater::ImuInitType priorG,
                                      ImuInitializater::ImuInitType priorA) {
-  Verbose::PrintMess("Starting inertial optimization", Verbose::VERBOSITY_NORMAL);
+  Verbose::PrintMess("start inertial optimization", Verbose::VERBOSITY_NORMAL);
   int its = 200;
   long unsigned int maxKFid = pMap->GetMaxKFid();
   const std::vector<KeyFrame*> vpKFs = pMap->GetAllKeyFrames();
@@ -222,7 +222,7 @@ void Optimizer::InertialOptimization(std::shared_ptr<Map> pMap, Eigen::Matrix3d&
     } else
       pKFi->SetNewBias(b);
   }
-  Verbose::PrintMess("Inertial optimization complete", Verbose::VERBOSITY_NORMAL);
+  Verbose::PrintMess("end inertial optimization", Verbose::VERBOSITY_NORMAL);
 }
 
 // used in LoopClosing

--- a/src/Optimizer/LocalInertialBA.cc
+++ b/src/Optimizer/LocalInertialBA.cc
@@ -527,8 +527,6 @@ void Optimizer::LocalInertialBA(KeyFrame* pKF, bool* pbStopFlag, std::shared_ptr
 
         // Monocular left observation
         if(leftIndex != -1 && pKFi->mvuRight[leftIndex] < 0) {
-          std::cout << "MONO LEFT OBSERVATION" << std::endl;
-
           // mVisEdges[pKFi->mnId].first++;
 
           kpUn = pKFi->mvKeysUn[leftIndex];

--- a/src/System.cc
+++ b/src/System.cc
@@ -165,10 +165,10 @@ System::System(const std::string& strVocFile, const std::string& strSettingsFile
   mpLoopCloser->SetTracker(mpTracker);
   mpLoopCloser->SetLocalMapper(mpLocalMapper);
 
-  std::cout << "Creating LocalMapping Thread in System" << std::endl;
+  std::cout << "Creating LocalMapping thread" << std::endl;
   mptLocalMapping = std::jthread(&MORB_SLAM::LocalMapping::Run, mpLocalMapper);
 
-  std::cout << "Creating LoopClosing Thread in System" << std::endl;
+  std::cout << "Creating LoopClosing thread" << std::endl;
   mptLoopClosing = std::jthread(&MORB_SLAM::LoopClosing::Run, mpLoopCloser);
 
   // Fix verbosity
@@ -206,9 +206,7 @@ StereoPacket System::TrackStereo(const cv::Mat& imLeft, const cv::Mat& imRight, 
   if (mSensor == CameraType::IMU_STEREO)
     mpTracker->GrabImuData(vImuMeas);
 
-  // std::cout << "start GrabImageStereo" << std::endl;
-  StereoPacket Tcw = mpTracker->GrabImageStereo(imLeftToFeed, imRightToFeed,
-                                                timestamp, cameras[0]); // for now we know cameras[0] is providing the image
+  StereoPacket Tcw = mpTracker->GrabImageStereo(imLeftToFeed, imRightToFeed, timestamp, cameras[0]); // for now we know cameras[0] is providing the image
 
   // Eigen::Vector3f vel = mpTracker->mCurrentFrame.GetVelocity();
 

--- a/src/Tracking.cc
+++ b/src/Tracking.cc
@@ -2863,14 +2863,10 @@ void Tracking::CheckTrackingModeChanged() {
 }
 
 void Tracking::CheckTrackingReset() {
-  std::scoped_lock<std::mutex> lock(mMutexReset);
-  if (mbReset) {
+  if(mbReset) {
     Reset();
-    mbReset = false;
-    mbResetActiveMap = false;
-  } else if (mbResetActiveMap) {
+  } else if(mbResetActiveMap) {
     ResetActiveMap();
-    mbResetActiveMap = false;
   }
 }
 

--- a/src/Viewer.cc
+++ b/src/Viewer.cc
@@ -44,7 +44,7 @@ Viewer::Viewer(const System_ptr &pSystem)
       both(false),
       mbClosed(false){
     newParameterLoader(*pSystem->getSettings());
-    std::cout << "Creating Thread in Viewer" << std::endl;
+    std::cout << "Creating Viewer thread" << std::endl;
     mptViewer = std::jthread(&Viewer::Run, this);
 }
 


### PR DESCRIPTION
- Fixes a bug that causes SLAM to hang indefinitely when ResetActiveMap() was called (was broken when the function was moved from the System class to Tracking) 
- Reduces the number of print statements spammed to the console
- Makes the remaining print statements are more descriptive