### PR TITLE
Fix KeyFrame::SetBadFlag() Implementation 

### DIFF
--- a/src/KeyFrame.cc
+++ b/src/KeyFrame.cc
@@ -635,7 +635,15 @@ bool KeyFrame::SetBadFlag() {
     std::unique_lock<std::mutex> lock(mMutexConnections);
     std::unique_lock<std::mutex> lock1(mMutexFeatures);
 
-    
+    if(mPrevKF) { 
+      mPrevKF->mNextKF = mNextKF;
+    }
+    if(mNextKF) {
+      if(mpImuPreintegrated && mNextKF->mpImuPreintegrated) {
+        mNextKF->mpImuPreintegrated->MergePrevious(mpImuPreintegrated);
+      }
+      mNextKF->mPrevKF = mPrevKF;
+    }
     mPrevKF = nullptr;
     mNextKF = nullptr;
     // mpParent;

--- a/src/LocalMapping.cc
+++ b/src/LocalMapping.cc
@@ -821,13 +821,6 @@ void LocalMapping::KeyFrameCulling() {
         }
         // std::cout << longTimeNotMoving << " " << nRedundantObservations << " > " << redundant_th * nMPs << std::endl;
         if (nRedundantObservations > redundant_th * nMPs) { // David comment: if the number of redundant map points are above the threshold and other requirements (mark for memory leak?) and do not do more than 100 or 20 maybe 
-            if (mbInertial) {
-                pKF->mNextKF->mpImuPreintegrated->MergePrevious(pKF->mpImuPreintegrated);
-                pKF->mNextKF->mPrevKF = pKF->mPrevKF;
-                pKF->mPrevKF->mNextKF = pKF->mNextKF;
-                pKF->mNextKF = nullptr;
-                pKF->mPrevKF = nullptr;
-            }
             pKF->SetBadFlag();
             // std::cout << "SetBadFlag called, there are now " << pKF.use_count() << " references to the KF" << std::endl;
         }

--- a/src/Optimizer/LocalInertialBA.cc
+++ b/src/Optimizer/LocalInertialBA.cc
@@ -251,17 +251,6 @@ void Optimizer::LocalInertialBA(std::shared_ptr<KeyFrame> pKF, bool* pbStopFlag,
     // Delete KFi by merging its previous and next KFs (code taken from LocalMapping's KeyFrameCulling function)
     if(pKFi->SetBadFlag()) {
       std::cout << "LocalInertialBA: Deleting KeyFrame " << pKFi->mnId << std::endl;
-      if(pKFi->mNextKF) {
-        if(pKFi->mpImuPreintegrated && pKFi->mNextKF->mpImuPreintegrated) {
-          pKFi->mNextKF->mpImuPreintegrated->MergePrevious(pKFi->mpImuPreintegrated);
-        }
-        pKFi->mNextKF->mPrevKF = pKFi->mPrevKF;
-      }
-      if(pKFi->mPrevKF) { 
-        pKFi->mPrevKF->mNextKF = pKFi->mNextKF;
-      }
-      pKFi->mNextKF = nullptr;
-      pKFi->mPrevKF = nullptr;
     }
   }
 


### PR DESCRIPTION
Move the KF merge process from the locations that SetBadFlag() is called into the actual function.

The previous implementation caused an issue where if SetBadFlag() was called on a KeyFrame marked SetNotErase, the SetBadFlag() function would be queued up without performing the KF merge process. Once the KF was marked with SetErase(), the queued SetBadFlag call would execute, and without the KF merge process, the system would crash when trying to optimize using that KF.