### PR TITLE
Feature: Enable external creation of Settings object

### DIFF
--- a/Examples/Stereo-Inertial/realsense_websocket_client.cpp
+++ b/Examples/Stereo-Inertial/realsense_websocket_client.cpp
@@ -9,15 +9,9 @@
 
 #include <MORB_SLAM/System.h>
 #include <MORB_SLAM/Viewer.h>
-#include "MORB_SLAM/ExternalIMUProcessor.h"
+#include <MORB_SLAM/ExternalIMUProcessor.h>
 
 #include <csignal>
-
-// Settings
-////////////////////////////////////////////////////////////////////////////////////////////////////////
-    const std::string websocket_host_address = "ws://172.26.0.1:8765";
-    const double time_unit_to_seconds_conversion_factor = 0.001;
-////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 bool exitSLAM = false;
 
@@ -29,6 +23,12 @@ void sigHandler(int sigNum) {
 
 int main(int argc, char **argv) {
     signal(SIGINT, sigHandler);
+
+    bool found;
+    std::string web_socket_config_path(argv[3]);
+    cv::FileStorage websocket_config = MORB_SLAM::Settings::loadFile(web_socket_config_path);
+    const std::string websocket_host_address = MORB_SLAM::Settings::readParameter<std::string>(websocket_config, "host_address", found, true);
+    const double time_unit_to_seconds_conversion_factor = 0.001;
 
     {
     ix::initNetSystem();
@@ -84,7 +84,8 @@ int main(int argc, char **argv) {
         }
     );
     
-    auto SLAM = std::make_shared<MORB_SLAM::System>(argv[1],argv[2], MORB_SLAM::CameraType::IMU_STEREO);
+    std::shared_ptr<MORB_SLAM::CameraSettings> cam_settings = std::make_shared<MORB_SLAM::CameraSettings>(argv[2], MORB_SLAM::CameraType::IMU_STEREO);
+    auto SLAM = std::make_shared<MORB_SLAM::System>(argv[1], cam_settings);
     auto viewer = std::make_shared<MORB_SLAM::Viewer>(SLAM);
 
     std::pair<double, std::vector<MORB_SLAM::IMU::Point>> slam_data;

--- a/Examples/Stereo-Inertial/run_websocket.sh
+++ b/Examples/Stereo-Inertial/run_websocket.sh
@@ -1,1 +1,1 @@
-gdb --args ../../bin/realsense_websocket_client ../../Vocabulary/ORBvoc.txt ./RealSense_D435i.yaml 
+gdb --args ../../bin/external_IMU_client ../../Vocabulary/ORBvoc.txt ./RealSense_D435i.yaml ./websocket.yaml

--- a/Examples/Stereo-Inertial/stereo_inertial_realsense_D435i.cc
+++ b/Examples/Stereo-Inertial/stereo_inertial_realsense_D435i.cc
@@ -33,6 +33,7 @@
 
 #include <MORB_SLAM/System.h>
 #include <MORB_SLAM/Viewer.h>
+#include <MORB_SLAM/CameraSettings.hpp>
 
 
 
@@ -346,7 +347,8 @@ int main(int argc, char **argv) {
 
 
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    auto SLAM = std::make_shared<MORB_SLAM::System>(argv[1],argv[2], MORB_SLAM::CameraType::IMU_STEREO);
+    std::shared_ptr<MORB_SLAM::CameraSettings> cam_settings = std::make_shared<MORB_SLAM::CameraSettings>(argv[2], MORB_SLAM::CameraType::IMU_STEREO);
+    auto SLAM = std::make_shared<MORB_SLAM::System>(argv[1], cam_settings);
     auto viewer = std::make_shared<MORB_SLAM::Viewer>(SLAM);
 
 

--- a/Examples/Stereo-Inertial/websocket.yaml
+++ b/Examples/Stereo-Inertial/websocket.yaml
@@ -1,0 +1,3 @@
+%YAML:1.0
+
+host_address: "ws://127.0.0.1:8765" # change this to the address of your websocket host

--- a/Testing/Stereo-Inertial/EuRoC/test_stereo_inertial_euroc.cpp
+++ b/Testing/Stereo-Inertial/EuRoC/test_stereo_inertial_euroc.cpp
@@ -30,16 +30,17 @@
 #include <MORB_SLAM/System.h>
 #include <MORB_SLAM/Viewer.h>
 #include <MORB_SLAM/ExternalMapViewer.h>
-#include "MORB_SLAM/ExternalIMUProcessor.h"
+#include <MORB_SLAM/ExternalIMUProcessor.h>
+#include <MORB_SLAM/CameraSettings.hpp>
 
-#include "MORB_SLAM/ImuTypes.h"
+#include <MORB_SLAM/ImuTypes.h>
 
 bool load_images(const std::filesystem::path &path_left_images, const std::filesystem::path &path_right_images, const std::filesystem::path &path_cam_csv,
                 std::vector<std::string> &v_str_image_left, std::vector<std::string> &v_str_image_right, std::vector<double> &v_timestamp_cam);
 
 bool load_imu(const std::filesystem::path &path_imu, std::vector<double> &v_timestamp_imu, std::vector<cv::Point3f> &v_acc, std::vector<cv::Point3f> &v_gyro);
 
-void write_imgs_to_video(const std::filesystem::path &output_vid_path, const std::vector<std::string> &v_img_paths, double frame_rate);
+void write_imgs_to_video(const std::filesystem::path &output_vid_path, const std::vector<std::string> &v_img_paths, float frame_rate);
 
 void write_pose_to_results(std::ofstream &results_file, Sophus::SE3f &pose, double timestamp);
 
@@ -107,13 +108,6 @@ int main(int argc, char **argv)
         std::cout << "There are " << num_images << " stereo images and " << num_imu << " rows of IMU data." << std::endl;
     }
 
-    // Check if camera settings can be read
-    cv::FileStorage camera_settings(argv[2], cv::FileStorage::READ);
-    if(!camera_settings.isOpened()) {
-        std::cerr << "ERROR: Wrong path to camera settings: " << argv[2] << std::endl;
-        return 1;
-    }
-
     // Start at the latest IMU measurement that was captured before (or during) the first camera frame
     while(v_timestamp_imu_s[first_imu_idx]<=v_timestamp_cam_s[0])
         ++first_imu_idx;
@@ -121,26 +115,26 @@ int main(int argc, char **argv)
 
     std::cout << "The first imu measurement to be considered is at index " << first_imu_idx << std::endl;
 
+    // Create CameraSettings object
+    std::shared_ptr<MORB_SLAM::CameraSettings> cam_settings = std::make_shared<MORB_SLAM::CameraSettings>(argv[2], MORB_SLAM::CameraType::IMU_STEREO);
+
     // Write the image sequences to a video, if a video doesn't exist
     std::filesystem::path output_vid_path_left = path_to_seq / "stereo_left.avi";
     std::filesystem::path output_vid_path_right = path_to_seq / "stereo_right.avi";
-    double frame_rate;
-    camera_settings["Camera.fps"] >> frame_rate;
 
     if(!std::filesystem::exists(output_vid_path_left)) {
         std::cout << "Creating a video using the left image sequence: " << output_vid_path_left << std::endl;
-        write_imgs_to_video(output_vid_path_left, v_str_image_left, frame_rate);
+        write_imgs_to_video(output_vid_path_left, v_str_image_left, cam_settings->fps());
     }
 
     if (!std::filesystem::exists(output_vid_path_right)) {
         std::cout << "Creating a video using the right image sequence: " << output_vid_path_right << std::endl;
-        write_imgs_to_video(output_vid_path_right, v_str_image_right, frame_rate);
+        write_imgs_to_video(output_vid_path_right, v_str_image_right, cam_settings->fps());
     }
 
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    auto SLAM = std::make_shared<MORB_SLAM::System>(argv[1],argv[2], MORB_SLAM::CameraType::IMU_STEREO);
+    auto SLAM = std::make_shared<MORB_SLAM::System>(argv[1], cam_settings);
     auto viewer = std::make_shared<MORB_SLAM::Viewer>(SLAM);
-    // std::cout << "Here are the SLAM settings: \n" << *(SLAM->getSettings()) << std::endl;
 
     std::vector<float> v_duration_track_s; // keeping track of how long each frame took to process
     v_duration_track_s.resize(num_images);
@@ -197,8 +191,6 @@ int main(int argc, char **argv)
             usleep((T - duration_s) * 1e6); // usleep uses microseconds
         }
     }
-
-    camera_settings.release();
 
     if(b_results_file) {
         results_file.close();
@@ -300,7 +292,7 @@ bool load_imu(const std::filesystem::path &path_imu, std::vector<double> &v_time
     return true;
 }
 
-void write_imgs_to_video(const std::filesystem::path &output_vid_path, const std::vector<std::string> &v_img_paths, double frame_rate) {
+void write_imgs_to_video(const std::filesystem::path &output_vid_path, const std::vector<std::string> &v_img_paths, float frame_rate) {
     cv::VideoWriter vid_writer;
     cv::Mat first_img = cv::imread(v_img_paths[0]);
     if (first_img.empty()) {

--- a/include/MORB_SLAM/CameraSettings.hpp
+++ b/include/MORB_SLAM/CameraSettings.hpp
@@ -1,0 +1,160 @@
+#pragma once
+
+#include "MORB_SLAM/Settings.h"
+
+#include "MORB_SLAM/CameraModels/GeometricCamera.h"
+#include "MORB_SLAM/ImprovedTypes.hpp"
+
+namespace MORB_SLAM {
+
+class CameraSettings : public Settings {
+public:
+    /*
+    * Enum for the different camera types implemented
+    */
+    enum CameraModelType { PinHole = 0, Rectified = 1, KannalaBrandt = 2 };
+
+    /* Constructor from file */
+    CameraSettings(const std::string& configFile, const CameraType& sensor);
+
+    /* Ostream operator overloading to dump settings to the terminal */
+    friend std::ostream& operator<<(std::ostream& output, const CameraSettings& s);
+
+    /* Getter methods */
+    CameraType cameraType() const { return sensor_; }
+    CameraModelType cameraModelType() const { return cameraModelType_; }
+    std::shared_ptr<const GeometricCamera> camera1() const { return std::const_pointer_cast<const GeometricCamera>(calibration1_); }
+    std::shared_ptr<const GeometricCamera> camera2() const { return std::const_pointer_cast<const GeometricCamera>(calibration2_); }
+
+    cv::Mat camera1DistortionCoef() { return cv::Mat(vPinHoleDistorsion1_.size(), 1, CV_32F, vPinHoleDistorsion1_.data()); }
+    cv::Mat camera2DistortionCoef() { return cv::Mat(vPinHoleDistorsion2_.size(), 1, CV_32F, vPinHoleDistorsion2_.data()); }
+
+    const Sophus::SE3f &Tlr() const { return Tlr_; }
+    float bf() const { return bf_; }
+    float b() const { return b_; }
+    float thDepth() const { return thDepth_; }
+
+    bool needToUndistort() const { return bNeedToUndistort_; }
+
+    const cv::Size &newImSize() const { return newImSize_; }
+    float fps() const { return fps_; }
+    bool needToResize() const { return bNeedToResize1_; }
+    bool needToRectify() const { return bNeedToRectify_; }
+
+    float noiseGyro() const { return noiseGyro_; }
+    float noiseAcc() const { return noiseAcc_; }
+    float gyroWalk() const { return gyroWalk_; }
+    float accWalk() const { return accWalk_; }
+    float accFrequency() const { return accFrequency_; }
+    float gyroFrequency() const { return gyroFrequency_; }
+    const Sophus::SE3f &Tbc() const { return Tbc_; }
+
+    float depthMapFactor() const { return depthMapFactor_; }
+
+    int nFeatures() const { return nFeatures_; }
+    int nLevels() const { return nLevels_; }
+    float initThFAST() const { return initThFAST_; }
+    float minThFAST() const { return minThFAST_; }
+    float scaleFactor() const { return scaleFactor_; }
+
+    float keyFrameSize() const { return keyFrameSize_; }
+    float keyFrameLineWidth() const { return keyFrameLineWidth_; }
+    float graphLineWidth() const { return graphLineWidth_; }
+    float pointSize() const { return pointSize_; }
+    float cameraSize() const { return cameraSize_; }
+    float cameraLineWidth() const { return cameraLineWidth_; }
+    float viewPointX() const { return viewPointX_; }
+    float viewPointY() const { return viewPointY_; }
+    float viewPointZ() const { return viewPointZ_; }
+    float viewPointF() const { return viewPointF_; }
+    float imageViewerScale() const { return imageViewerScale_; }
+
+    const std::string &atlasLoadFile() const { return sLoadFrom_; }
+    const std::string &atlasSaveFile() const { return sSaveto_; }
+
+    float thFarPoints() const { return thFarPoints_; }
+    bool activeLoopClosing() const { return activeLoopClosing_; }
+    bool fastIMUInit() const { return fastIMUInit_; }
+    bool stationaryIMUInit() const { return stationaryIMUInit_; }
+    bool newMapRelocalization() const { return newMapRelocalization_; }
+
+    const cv::Mat &M1l() const { return M1l_; }
+    const cv::Mat &M2l() const { return M2l_; }
+    const cv::Mat &M1r() const { return M1r_; }
+    const cv::Mat &M2r() const { return M2r_; }
+
+private:
+
+    void readCamera1(cv::FileStorage& fSettings);
+    void readCamera2(cv::FileStorage& fSettings);
+    void readImageInfo(cv::FileStorage& fSettings);
+    void readIMU(cv::FileStorage& fSettings);
+    void readRGBD(cv::FileStorage& fSettings);
+    void readORB(cv::FileStorage& fSettings);
+    void readViewer(cv::FileStorage& fSettings);
+    void readLoadAndSave(cv::FileStorage& fSettings);
+    void readOtherParameters(cv::FileStorage& fSettings);
+
+    void precomputeRectificationMaps();
+
+    CameraType sensor_;
+    CameraModelType cameraModelType_;
+
+    /* Visual stuff */
+    std::shared_ptr<GeometricCamera> calibration1_, calibration2_;  // Camera calibration
+    std::vector<float> vPinHoleDistorsion1_, vPinHoleDistorsion2_;
+
+    cv::Size originalImSize_, newImSize_;
+    float fps_;
+
+    bool bNeedToUndistort_;
+    bool bNeedToRectify_;
+    bool bNeedToResize1_, bNeedToResize2_;
+
+    Sophus::SE3f Tlr_;
+    float thDepth_;
+    float bf_, b_;
+
+    /* Rectification stuff */
+    cv::Mat M1l_, M2l_;
+    cv::Mat M1r_, M2r_;
+
+    /* Inertial stuff */
+    float noiseGyro_, noiseAcc_;
+    float gyroWalk_, accWalk_;
+    float accFrequency_;
+    float gyroFrequency_;
+    Sophus::SE3f Tbc_;
+
+    /* RGBD stuff */
+    float depthMapFactor_;
+
+    /* ORB stuff */
+    int nFeatures_;
+    float scaleFactor_;
+    int nLevels_;
+    int initThFAST_, minThFAST_;
+
+    /* Viewer stuff */
+    float keyFrameSize_;
+    float keyFrameLineWidth_;
+    float graphLineWidth_;
+    float pointSize_;
+    float cameraSize_;
+    float cameraLineWidth_;
+    float viewPointX_, viewPointY_, viewPointZ_, viewPointF_;
+    float imageViewerScale_;
+
+    /* Save & load maps */
+    std::string sLoadFrom_, sSaveto_;
+
+    /* Other stuff */
+    float thFarPoints_;
+    bool activeLoopClosing_;
+    bool fastIMUInit_;
+    bool stationaryIMUInit_;
+    bool newMapRelocalization_;
+};
+
+
+} // namespace MORB_SLAM

--- a/include/MORB_SLAM/Frame.h
+++ b/include/MORB_SLAM/Frame.h
@@ -37,7 +37,7 @@
 #include "MORB_SLAM/ImuTypes.h"
 #include "MORB_SLAM/ORBVocabulary.h"
 #include "MORB_SLAM/Converter.h"
-#include "MORB_SLAM/Settings.h"
+#include "MORB_SLAM/CameraSettings.hpp"
 #include "MORB_SLAM/Camera.hpp"
 
 

--- a/include/MORB_SLAM/MapDrawer.h
+++ b/include/MORB_SLAM/MapDrawer.h
@@ -27,12 +27,12 @@
 namespace MORB_SLAM
 {
 
-class Settings;
+class CameraSettings;
 class KeyFrame;
 
 class MapDrawer
 {
-    void newParameterLoader(const Settings& settings);
+    void newParameterLoader(const CameraSettings& settings);
     Atlas_ptr mpAtlas;
     
     float mKeyFrameSize;
@@ -54,7 +54,7 @@ class MapDrawer
                                 {0.0f, 1.0f, 1.0f}};
 
 public:
-    MapDrawer(const Atlas_ptr &pAtlas, const Settings& settings);
+    MapDrawer(const Atlas_ptr &pAtlas, const CameraSettings& settings);
 
     void DrawMapPoints();
     void DrawKeyFrames(const bool bDrawKF, const bool bDrawGraph, const bool bDrawInertialGraph, const bool bDrawOptLba);

--- a/include/MORB_SLAM/System.h
+++ b/include/MORB_SLAM/System.h
@@ -35,7 +35,7 @@
 #include "MORB_SLAM/KeyFrameDatabase.h"
 #include "MORB_SLAM/ORBVocabulary.h"
 #include "MORB_SLAM/ImuTypes.h"
-#include "MORB_SLAM/Settings.h"
+#include "MORB_SLAM/CameraSettings.hpp"
 #include "MORB_SLAM/Camera.hpp"
 #include "MORB_SLAM/Packet.hpp"
 
@@ -49,7 +49,7 @@ class Atlas;
 class Tracking;
 class LocalMapping;
 class LoopClosing;
-class Settings;
+class CameraSettings;
 typedef std::shared_ptr<Tracking> Tracking_ptr;
 
 class System {
@@ -63,7 +63,7 @@ class System {
  public:
     
     // Initialize the SLAM system. It launches the Local Mapping, Loop Closing and Viewer threads.
-    System(const std::string &strVocFile, const std::string &strSettingsFile, const CameraType sensor);
+    System(const std::string &strVocFile, std::shared_ptr<CameraSettings> camSettings);
 
     // Proccess the given stereo frame. Images must be synchronized and rectified.
     // Input images: RGB (CV_8UC3) or grayscale (CV_8U). RGB is converted to grayscale.
@@ -99,7 +99,7 @@ class System {
     bool getHasMergedLocalMap();
     bool getIsDoneVIBA();
 
-    std::shared_ptr<Settings> getSettings() const;
+    std::shared_ptr<CameraSettings> getSettings() const;
 
     bool getIsLoopClosed();
     void setIsLoopClosed(bool isLoopClosed);
@@ -154,7 +154,7 @@ private:
 
     std::string mStrVocabularyFilePath;
 
-    std::shared_ptr<Settings> settings;
+    std::shared_ptr<CameraSettings> settings;
 
 };
 typedef std::shared_ptr<System> System_ptr;

--- a/include/MORB_SLAM/Tracking.h
+++ b/include/MORB_SLAM/Tracking.h
@@ -36,7 +36,7 @@
 #include "MORB_SLAM/LoopClosing.h"
 #include "MORB_SLAM/ORBVocabulary.h"
 #include "MORB_SLAM/ORBextractor.h"
-#include "MORB_SLAM/Settings.h"
+#include "MORB_SLAM/CameraSettings.hpp"
 #include "MORB_SLAM/Verbose.h"
 #include "MORB_SLAM/ImprovedTypes.hpp"
 #include "MORB_SLAM/Camera.hpp"
@@ -50,7 +50,7 @@ class LoopClosing;
 class Tracking {
  public:
   
-  Tracking(std::shared_ptr<ORBVocabulary> pVoc, const Atlas_ptr &pAtlas, std::shared_ptr<KeyFrameDatabase> pKFDB, const CameraType sensor, std::shared_ptr<Settings> settings);
+  Tracking(std::shared_ptr<ORBVocabulary> pVoc, const Atlas_ptr &pAtlas, std::shared_ptr<KeyFrameDatabase> pKFDB, const CameraType sensor, std::shared_ptr<CameraSettings> settings);
 
   ~Tracking();
 
@@ -270,7 +270,7 @@ public:
 
   Sophus::SE3f mTlr;
 
-  void newParameterLoader(Settings& settings);
+  void newParameterLoader(CameraSettings& settings);
 
   bool mForcedLost;
 

--- a/include/MORB_SLAM/Viewer.h
+++ b/include/MORB_SLAM/Viewer.h
@@ -29,7 +29,7 @@
 #include "MORB_SLAM/ImprovedTypes.hpp"
 #include "MORB_SLAM/FrameDrawer.h"
 #include "MORB_SLAM/MapDrawer.h"
-#include "MORB_SLAM/Settings.h"
+#include "MORB_SLAM/CameraSettings.hpp"
 #include "MORB_SLAM/Packet.hpp"
 
 namespace MORB_SLAM {
@@ -38,7 +38,7 @@ class Viewer {
 
 typedef std::shared_ptr<System> System_ptr;
 
-void newParameterLoader(const Settings& settings);
+void newParameterLoader(const CameraSettings& settings);
 // Main thread function. Draw points, keyframes, the current camera pose and the last processed frame. Drawing is refreshed according to the camera fps. We use Pangolin.
 void Run();
  public:

--- a/src/MapDrawer.cc
+++ b/src/MapDrawer.cc
@@ -32,11 +32,11 @@
 
 namespace MORB_SLAM {
 
-MapDrawer::MapDrawer(const Atlas_ptr &pAtlas, const Settings& settings): mpAtlas(pAtlas){
+MapDrawer::MapDrawer(const Atlas_ptr &pAtlas, const CameraSettings& settings): mpAtlas(pAtlas){
   newParameterLoader(settings);
 }
 
-void MapDrawer::newParameterLoader(const Settings &settings) {
+void MapDrawer::newParameterLoader(const CameraSettings &settings) {
   mKeyFrameSize = settings.keyFrameSize();
   mKeyFrameLineWidth = settings.keyFrameLineWidth();
   mGraphLineWidth = settings.graphLineWidth();

--- a/src/System.cc
+++ b/src/System.cc
@@ -48,10 +48,11 @@ namespace MORB_SLAM {
 
 Verbose::eLevel Verbose::th = Verbose::VERBOSITY_NORMAL;
 
-System::System(const std::string& strVocFile, const std::string& strSettingsFile, const CameraType sensor)
-    : mSensor(sensor),
+System::System(const std::string &strVocFile, std::shared_ptr<CameraSettings> camSettings)
+    : mSensor(camSettings->cameraType()),
       mpAtlas(std::make_shared<Atlas>(0)),
-      mTrackingState(TrackingState::SYSTEM_NOT_READY) {
+      mTrackingState(TrackingState::SYSTEM_NOT_READY),
+      settings(camSettings) {
 
   cameras.push_back(std::make_shared<Camera>(mSensor)); // for now just hard code the sensor we are using, TODO make multicam
   // Output welcome message
@@ -60,7 +61,6 @@ System::System(const std::string& strVocFile, const std::string& strSettingsFile
   // We're legally obligated to keep this line
   std::cout << std::endl << "ORB-SLAM3 Copyright (C) 2017-2020 Carlos Campos, Richard Elvira, Juan J. Gómez, José M.M. Montiel and Juan D. Tardós, University of Zaragoza." << std::endl << "ORB-SLAM2 Copyright (C) 2014-2016 Raúl Mur-Artal, José M.M. Montiel and Juan D. Tardós, University of Zaragoza." << std::endl << "This program comes with ABSOLUTELY NO WARRANTY;" << std::endl << "This is free software, and you are welcome to redistribute it" << std::endl << "under certain conditions. See LICENSE.txt." << std::endl << std::endl;
   
-  settings = std::make_shared<Settings>(strSettingsFile, mSensor);
   mStrLoadAtlasFromFile = settings->atlasLoadFile();
   mStrSaveAtlasToFile = settings->atlasSaveFile();
 
@@ -446,7 +446,7 @@ bool System::getIsDoneVIBA() {
   return mpLocalMapper->getIsDoneVIBA();
 }
 
-std::shared_ptr<Settings> System::getSettings() const { return settings; }
+std::shared_ptr<CameraSettings> System::getSettings() const { return settings; }
 
 // Bonk
 void System::ForceLost() { mpTracker->setForcedLost(true); }

--- a/src/Tracking.cc
+++ b/src/Tracking.cc
@@ -41,7 +41,7 @@
 namespace MORB_SLAM {
 
 Tracking::Tracking(std::shared_ptr<ORBVocabulary> pVoc, const Atlas_ptr &pAtlas,
-                   std::shared_ptr<KeyFrameDatabase> pKFDB, const CameraType sensor, std::shared_ptr<Settings> settings)
+                   std::shared_ptr<KeyFrameDatabase> pKFDB, const CameraType sensor, std::shared_ptr<CameraSettings> settings)
     : mState(TrackingState::NO_IMAGES_YET),
       mLastProcessedState(TrackingState::NO_IMAGES_YET),
       mSensor(sensor),
@@ -95,7 +95,7 @@ Tracking::Tracking(std::shared_ptr<ORBVocabulary> pVoc, const Atlas_ptr &pAtlas,
 
 Tracking::~Tracking() {}
 
-void Tracking::newParameterLoader(Settings& settings) {
+void Tracking::newParameterLoader(CameraSettings& settings) {
   mpCamera = settings.camera1();
   mpCamera = mpAtlas->AddCamera(mpCamera);
 
@@ -111,7 +111,7 @@ void Tracking::newParameterLoader(Settings& settings) {
   mK.at<float>(0, 2) = mpCamera->getParameter(2);
   mK.at<float>(1, 2) = mpCamera->getParameter(3);
 
-  if (mSensor.hasMulticam() && settings.cameraModelType() == Settings::KannalaBrandt) {
+  if (mSensor.hasMulticam() && settings.cameraModelType() == CameraSettings::KannalaBrandt) {
     mpCamera2 = settings.camera2();
     mpCamera2 = mpAtlas->AddCamera(mpCamera2);
 

--- a/src/Viewer.cc
+++ b/src/Viewer.cc
@@ -54,7 +54,7 @@ Viewer::~Viewer(){
   if(mptViewer.joinable()) mptViewer.join();
 }
 
-void Viewer::newParameterLoader(const Settings &settings) {
+void Viewer::newParameterLoader(const CameraSettings &settings) {
   mImageViewerScale = 1.f;
 
   float fps = settings.fps();
@@ -71,7 +71,7 @@ void Viewer::newParameterLoader(const Settings &settings) {
   mViewpointZ = settings.viewPointZ();
   mViewpointF = settings.viewPointF();
 
-  if ((mpTracker->mSensor == CameraType::STEREO || mpTracker->mSensor == CameraType::IMU_STEREO || mpTracker->mSensor == CameraType::IMU_RGBD || mpTracker->mSensor == CameraType::RGBD) && settings.cameraModelType() == Settings::KannalaBrandt) {
+  if ((mpTracker->mSensor == CameraType::STEREO || mpTracker->mSensor == CameraType::IMU_STEREO || mpTracker->mSensor == CameraType::IMU_RGBD || mpTracker->mSensor == CameraType::RGBD) && settings.cameraModelType() == CameraSettings::KannalaBrandt) {
     both = true;
     mpFrameDrawer.both = true;
   }


### PR DESCRIPTION
# Description & Motivation

Addresses some of the issues raised in #25.  

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Changes

* Create a base MORB_SLAM::Settings class for reading from config files
* Create a MORB_SLAM::CameraSettings class so a camera settings object can be created externally and passed into MORB_SLAM::System
* Update existing testing/example programs using MORB_SLAM to follow this convention

The base MORB_SLAM::Settings class has static methods to allow users to do general operations such as readParameter() and loadFile() when working with config files. An example is shown in `Examples/Stereo-Inertial/external_IMU_client.cpp`.

The MORB_SLAM::CameraSettings class inherits the MORB_SLAM::Settings class and is used throughout MORB_SLAM::System.