### PR TITLE
Fix compilation issues on specific version of boost

### DIFF
--- a/include/MORB_SLAM/KeyFrameDatabase.h
+++ b/include/MORB_SLAM/KeyFrameDatabase.h
@@ -21,10 +21,18 @@
 
 #pragma once
 
-#include <boost/serialization/base_object.hpp>
-#if BOOST_VERSION >= 107400 // Newer versions of boost (>=1.74) require this header
+/* This <boost/serialization/library_version_type.hpp> include guards against an issue
+ * in boost::serialization from boost 1.74.0 that leads to compiler error
+ * "error: ‘library_version_type’ in namespace ‘boost::serialization’ does not name a type;" 
+ * when including <boost/serialization/list.hpp>. More details in ticket:
+ * https://github.com/borglab/gtsam/issues/1412
+ * https://github.com/boostorg/serialization/issues/219
+ */
+#if BOOST_VERSION >= 107400
 #include <boost/serialization/library_version_type.hpp>
 #endif
+
+#include <boost/serialization/base_object.hpp>
 #include <boost/serialization/list.hpp>
 #include <boost/serialization/vector.hpp>
 #include <list>

--- a/include/MORB_SLAM/KeyFrameDatabase.h
+++ b/include/MORB_SLAM/KeyFrameDatabase.h
@@ -22,6 +22,9 @@
 #pragma once
 
 #include <boost/serialization/base_object.hpp>
+#if BOOST_VERSION >= 107400 // Newer versions of boost (>=1.74) require this header
+#include <boost/serialization/library_version_type.hpp>
+#endif
 #include <boost/serialization/list.hpp>
 #include <boost/serialization/vector.hpp>
 #include <list>
@@ -77,7 +80,7 @@ class KeyFrameDatabase {
   std::shared_ptr<ORBVocabulary> mpVoc;
 
   // Inverted file
-  std::vector<std::list<std::shared_ptr<KeyFrame>> > mvInvertedFile;
+  std::vector<std::list<std::shared_ptr<KeyFrame>>> mvInvertedFile;
 
   // For save relation without pointer, this is necessary for save/load function
   std::vector<std::list<long unsigned int>> mvBackupInvertedFileId;

--- a/include/MORB_SLAM/Settings/Settings.h
+++ b/include/MORB_SLAM/Settings/Settings.h
@@ -21,159 +21,34 @@
 
 #pragma once
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <unistd.h>
-#include <memory>
-#include <stdexcept>
-#include <string>
-
-#include <opencv2/core/core.hpp>
-#include <iostream>
-
 #include "MORB_SLAM/Verbose.h"
-
+#include <opencv2/core/core.hpp>
+#include <string>
 
 namespace MORB_SLAM {
 
-
 class Settings {
 public:
-  static cv::FileStorage loadFile(const std::string configFile) {
-    cv::FileStorage fSettings(configFile, cv::FileStorage::READ);
-    if (!fSettings.isOpened()) {
-      Verbose::Log(Verbose::FATAL, "Could not open configuration file at: ", configFile);
-      throw std::invalid_argument("Could not open configuration file at: " + configFile);
-    } else {
-      Verbose::Log(Verbose::INFO, "Loading settings from ", configFile);
-      return fSettings;
-    }
-  }
+  static cv::FileStorage loadFile(const std::string configFile);
 
   template <typename T>
-  static T readParameter(const cv::FileStorage& settings, const std::string& name, bool& found, const bool required = true) {
-    cv::FileNode node = settings[name];
-    if (node.empty()) {
-      if (required) {
-        Verbose::Log(Verbose::FATAL, name, " required parameter does not exist, aborting...");
-        throw std::invalid_argument(name + " required parameter does not exist, aborting...");
-      } else {
-        Verbose::Log(Verbose::WARNING, name, " optional parameter does not exist...");
-        found = false;
-        return T();
-      }
-    } else {
-      found = true;
-      return (T)node;
-    }
-  }
-
-  template <>
-  bool readParameter<bool>(const cv::FileStorage& settings, const std::string& name, bool& found, const bool required) {
-    cv::FileNode node = settings[name];
-    if (node.empty()) {
-      if (required) {
-        Verbose::Log(Verbose::FATAL, name, " required parameter does not exist, aborting...");
-        throw std::invalid_argument(name + " required parameter does not exist, aborting...");
-      } else {
-        Verbose::Log(Verbose::WARNING, name, " optional parameter does not exist...");
-        found = false;
-        return false;
-      }
-    } else if(node.isString()) {
-      found = true;
-      std::string s = node.string();
-      if(s=="y"||s=="Y"||s=="yes"||s=="Yes"||s=="YES"||s=="true"||s=="True"||s=="TRUE"||s=="on"||s=="On"||s=="ON")
-        return true;
-      else if(s=="n"||s=="N"||s=="no"||s=="No"||s=="NO"||s=="false"||s=="False"||s=="FALSE"||s=="off"||s=="Off"||s=="OFF")
-        return false;
-    }
-    throw std::invalid_argument(name + " bool setting was not set to a valid string");
-  }
-
-  template <>
-  float readParameter<float>(const cv::FileStorage& settings, const std::string& name, bool& found, const bool required) {
-    cv::FileNode node = settings[name];
-    if (node.empty()) {
-      if (required) {
-        Verbose::Log(Verbose::FATAL, name, " required parameter does not exist, aborting...");
-        throw std::invalid_argument(name + " required parameter does not exist, aborting...");
-      } else {
-        Verbose::Log(Verbose::WARNING, name, " optional parameter does not exist...");
-        found = false;
-        return 0.0f;
-      }
-    } else if (!node.isReal()) {
-      Verbose::Log(Verbose::FATAL, name, " parameter must be a real number, aborting...");
-      throw std::invalid_argument(name + " parameter must be a real number, aborting...");
-    } else {
-      found = true;
-      return node.real();
-    }
-  }
-
-  template <>
-  int readParameter<int>(const cv::FileStorage& settings, const std::string& name, bool& found, const bool required) {
-    cv::FileNode node = settings[name];
-    if (node.empty()) {
-      if (required) {
-        Verbose::Log(Verbose::FATAL, name, " required parameter does not exist, aborting...");
-        throw std::invalid_argument(name + " required parameter does not exist, aborting...");
-      } else {
-        Verbose::Log(Verbose::WARNING, name, " optional parameter does not exist...");
-        found = false;
-        return 0;
-      }
-    } else if (!node.isInt()) {
-      Verbose::Log(Verbose::FATAL, name, " parameter must be an integer number, aborting...");
-      throw std::invalid_argument(name + " parameter must be an integer number, aborting...");
-    } else {
-      found = true;
-      return node.operator int();
-    }
-  }
-
-  template <>
-  std::string readParameter<std::string>(const cv::FileStorage& settings, const std::string& name, bool& found, const bool required) {
-    cv::FileNode node = settings[name];
-    if (node.empty()) {
-      if (required) {
-        Verbose::Log(Verbose::FATAL, name, " required parameter does not exist, aborting...");
-        throw std::invalid_argument(name + " required parameter does not exist, aborting...");
-      } else {
-        Verbose::Log(Verbose::WARNING, name, " optional parameter does not exist...");
-        found = false;
-        return std::string();
-      }
-    } else if (!node.isString()) {
-      Verbose::Log(Verbose::FATAL, name, " parameter must be a std::string, aborting...");
-      throw std::invalid_argument(name + " parameter must be a std::string, aborting...");
-    } else {
-      found = true;
-      return node.string();
-    }
-  }
-
-  template <>
-  cv::Mat readParameter<cv::Mat>(const cv::FileStorage& settings, const std::string& name, bool& found, const bool required) {
-    cv::FileNode node = settings[name];
-    if (node.empty()) {
-      if (required) {
-        Verbose::Log(Verbose::FATAL, name, " required parameter does not exist, aborting...");
-        throw std::invalid_argument(name + " required parameter does not exist, aborting...");
-      } else {
-        Verbose::Log(Verbose::WARNING, name, " optional parameter does not exist...");
-        found = false;
-        return cv::Mat();
-      }
-    } else {
-      found = true;
-      return node.mat();
-    }
-  }
-  
+  static T readParameter(const cv::FileStorage &settings, const std::string &name, bool &found, const bool required = true);
 };
 
+// Specializations must be declared outside the class:
+template <>
+bool Settings::readParameter<bool>(const cv::FileStorage &settings, const std::string &name, bool &found, const bool required);
 
-}  // namespace MORB_SLAM
+template <>
+float Settings::readParameter<float>(const cv::FileStorage &settings, const std::string &name, bool &found, const bool required);
 
+template <>
+int Settings::readParameter<int>(const cv::FileStorage &settings, const std::string &name, bool &found, const bool required);
+
+template <>
+std::string Settings::readParameter<std::string>(const cv::FileStorage &settings, const std::string &name, bool &found, const bool required);
+
+template <>
+cv::Mat Settings::readParameter<cv::Mat>(const cv::FileStorage &settings, const std::string &name, bool &found, const bool required);
+
+} // namespace MORB_SLAM

--- a/src/Settings/Settings.cpp
+++ b/src/Settings/Settings.cpp
@@ -1,0 +1,142 @@
+#include "MORB_SLAM/Settings/Settings.h"
+
+#include <stdexcept>
+
+namespace MORB_SLAM {
+
+cv::FileStorage Settings::loadFile(const std::string configFile) {
+  cv::FileStorage fSettings(configFile, cv::FileStorage::READ);
+    if (!fSettings.isOpened()) {
+      Verbose::Log(Verbose::FATAL, "Could not open configuration file at: ", configFile);
+      throw std::invalid_argument("Could not open configuration file at: " + configFile);
+    } else {
+      Verbose::Log(Verbose::INFO, "Loading settings from ", configFile);
+      return fSettings;
+    }
+}
+
+template <typename T>
+T Settings::readParameter(const cv::FileStorage &settings, const std::string &name, bool &found, const bool required) {
+  cv::FileNode node = settings[name];
+  if (node.empty()) {
+    if (required) {
+      Verbose::Log(Verbose::FATAL, name, " required parameter does not exist, aborting...");
+      throw std::invalid_argument(name + " required parameter does not exist, aborting...");
+    } else {
+      Verbose::Log(Verbose::WARNING, name, " optional parameter does not exist...");
+      found = false;
+      return T();
+    }
+  } else {
+    found = true;
+    return (T)node;
+  }
+}
+
+template <>
+bool Settings::readParameter<bool>(const cv::FileStorage &settings, const std::string &name, bool &found, const bool required) {
+  cv::FileNode node = settings[name];
+  if (node.empty()) {
+    if (required) {
+      Verbose::Log(Verbose::FATAL, name, " required parameter does not exist, aborting...");
+      throw std::invalid_argument(name + " required parameter does not exist, aborting...");
+    } else {
+      Verbose::Log(Verbose::WARNING, name, " optional parameter does not exist...");
+      found = false;
+      return false;
+    }
+  } else if(node.isString()) {
+    found = true;
+    std::string s = node.string();
+    if(s=="y"||s=="Y"||s=="yes"||s=="Yes"||s=="YES"||s=="true"||s=="True"||s=="TRUE"||s=="on"||s=="On"||s=="ON")
+      return true;
+    else if(s=="n"||s=="N"||s=="no"||s=="No"||s=="NO"||s=="false"||s=="False"||s=="FALSE"||s=="off"||s=="Off"||s=="OFF")
+      return false;
+  }
+  Verbose::Log(Verbose::FATAL, name, " bool setting was not set to a valid string");
+  throw std::invalid_argument(name + " bool setting was not set to a valid string");
+}
+
+template <>
+float Settings::readParameter<float>(const cv::FileStorage &settings, const std::string &name, bool &found, const bool required) {
+  cv::FileNode node = settings[name];
+  if (node.empty()) {
+    if (required) {
+      Verbose::Log(Verbose::FATAL, name, " required parameter does not exist, aborting...");
+      throw std::invalid_argument(name + " required parameter does not exist, aborting...");
+    } else {
+      Verbose::Log(Verbose::WARNING, name, " optional parameter does not exist...");
+      found = false;
+      return 0.0f;
+    }
+  } else if (!node.isReal()) {
+    Verbose::Log(Verbose::FATAL, name, " parameter must be a real number, aborting...");
+    throw std::invalid_argument(name + " parameter must be a real number, aborting...");
+  } else {
+    found = true;
+    return node.real();
+  }
+}
+
+template <>
+int Settings::readParameter<int>(const cv::FileStorage &settings, const std::string &name, bool &found, const bool required) {
+  cv::FileNode node = settings[name];
+  if (node.empty()) {
+    if (required) {
+      Verbose::Log(Verbose::FATAL, name, " required parameter does not exist, aborting...");
+      throw std::invalid_argument(name + " required parameter does not exist, aborting...");
+    } else {
+      Verbose::Log(Verbose::WARNING, name, " optional parameter does not exist...");
+      found = false;
+      return 0;
+    }
+  } else if (!node.isInt()) {
+    Verbose::Log(Verbose::FATAL, name, " parameter must be an integer number, aborting...");
+    throw std::invalid_argument(name + " parameter must be an integer number, aborting...");
+  } else {
+    found = true;
+    return node.operator int();
+  }
+}
+
+template <>
+std::string
+Settings::readParameter<std::string>(const cv::FileStorage &settings, const std::string &name, bool &found, const bool required) {
+  cv::FileNode node = settings[name];
+  if (node.empty()) {
+    if (required) {
+      Verbose::Log(Verbose::FATAL, name, " required parameter does not exist, aborting...");
+      throw std::invalid_argument(name + " required parameter does not exist, aborting...");
+    } else {
+      Verbose::Log(Verbose::WARNING, name, " optional parameter does not exist...");
+      found = false;
+      return std::string();
+    }
+  } else if (!node.isString()) {
+    Verbose::Log(Verbose::FATAL, name, " parameter must be a std::string, aborting...");
+    throw std::invalid_argument(name + " parameter must be a std::string, aborting...");
+  } else {
+    found = true;
+    return node.string();
+  }
+}
+
+template <>
+cv::Mat Settings::readParameter<cv::Mat>(const cv::FileStorage &settings, const std::string &name, bool &found, const bool required) {
+  cv::FileNode node = settings[name];
+  if (node.empty()) {
+    if (required) {
+      Verbose::Log(Verbose::FATAL, name, " required parameter does not exist, aborting...");
+      throw std::invalid_argument(name + " required parameter does not exist, aborting...");
+    } else {
+      Verbose::Log(Verbose::WARNING, name, " optional parameter does not exist...");
+      found = false;
+      return cv::Mat();
+    }
+  } else {
+    found = true;
+    return node.mat();
+  }
+}
+
+} // namespace MORB_SLAM


### PR DESCRIPTION
On older versions of gcc the Settings template definitions must be moved to a dedicated file to get around the following error:

```
Extracting ORB vocabulary...
ORBvoc.txt
-- No vcpkg toolchain file specified
-- The C compiler identification is GNU 11.4.0
-- The CXX compiler identification is GNU 11.4.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found OpenCV: /usr (found version "4.5.4") 
-- Found Boost: /usr/lib/x86_64-linux-gnu/cmake/Boost-1.74.0/BoostConfig.cmake (found version "1.74.0") found components: serialization regex 
-- Found Boost: /usr/lib/x86_64-linux-gnu/cmake/Boost-1.74.0/BoostConfig.cmake (found version "1.74.0")  
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE  
-- Found Boost: /usr/lib/x86_64-linux-gnu/cmake/Boost-1.74.0/BoostConfig.cmake (found version "1.74.0") found components: serialization regex 
-- Found Boost: /usr/lib/x86_64-linux-gnu/cmake/Boost-1.74.0/BoostConfig.cmake (found version "1.74.0")  
-- Found OpenSSL: /usr/lib/x86_64-linux-gnu/libcrypto.so (found version "3.0.2")  
-- ** Realsense websocket client will not compile because ixwebsocket was not found
-- Configuring done
-- Generating done
-- Build files have been written to: /MORB_SLAM/build
[0/2] Re-checking globbed directories...
[1/93] Building CXX object CMakeFiles/MORB_SLAM.dir/src/Camera.cpp.o
[2/93] Building CXX object CMakeFiles/MORB_SLAM.dir/src/Atlas.cc.o
FAILED: CMakeFiles/MORB_SLAM.dir/src/Atlas.cc.o 
/usr/bin/c++ -DBOOST_ALL_NO_LIB -DBOOST_REGEX_DYN_LINK -DBOOST_SERIALIZATION_DYN_LINK -DHAVE_EIGEN -DHAVE_GLEW -DHAVE_PYTHON -DMORB_SLAM_EXPORTS -DPANGO_DEFAULT_WIN_URI=\"x11\" -D_LINUX_ -I/MORB_SLAM/include -I/MORB_SLAM/Thirdparty/DBoW2 -I/MORB_SLAM/Thirdparty/g2o -I/MORB_SLAM/Thirdparty/Sophus -isystem /usr/include/opencv4 -isystem /usr/include/eigen3 -gdwarf-4 -fdiagnostics-color=always -O3 -DNDEBUG -fPIC -std=gnu++20 -MD -MT CMakeFiles/MORB_SLAM.dir/src/Atlas.cc.o -MF CMakeFiles/MORB_SLAM.dir/src/Atlas.cc.o.d -o CMakeFiles/MORB_SLAM.dir/src/Atlas.cc.o -c /MORB_SLAM/src/Atlas.cc
In file included from /MORB_SLAM/include/MORB_SLAM/Settings/CameraSettings.hpp:3,
                 from /MORB_SLAM/include/MORB_SLAM/Frame.h:39,
                 from /MORB_SLAM/include/MORB_SLAM/KeyFrame.h:42,
                 from /MORB_SLAM/include/MORB_SLAM/Atlas.h:34,
                 from /MORB_SLAM/src/Atlas.cc:22:
/MORB_SLAM/include/MORB_SLAM/Settings/Settings.h:71:13: error: explicit specialization in non-namespace scope 'class MORB_SLAM::Settings'
   71 |   template <>
      |             ^
/MORB_SLAM/include/MORB_SLAM/Settings/Settings.h:72:8: error: template-id 'readParameter<bool>' in declaration of primary template
   72 |   bool readParameter<bool>(const cv::FileStorage& settings, const std::string& name, bool& found, const bool required) {
      |        ^~~~~~~~~~~~~~~~~~~
/MORB_SLAM/include/MORB_SLAM/Settings/Settings.h:94:13: error: explicit specialization in non-namespace scope 'class MORB_SLAM::Settings'
   94 |   template <>
      |             ^
/MORB_SLAM/include/MORB_SLAM/Settings/Settings.h:95:9: error: template-id 'readParameter<float>' in declaration of primary template
   95 |   float readParameter<float>(const cv::FileStorage& settings, const std::string& name, bool& found, const bool required) {
      |         ^~~~~~~~~~~~~~~~~~~~
/MORB_SLAM/include/MORB_SLAM/Settings/Settings.h:95:9: error: 'float MORB_SLAM::Settings::readParameter(const cv::FileStorage&, const string&, bool&, bool)' cannot be overloaded with 'bool MORB_SLAM::Settings::readParameter(const cv::FileStorage&, const string&, bool&, bool)'
/MORB_SLAM/include/MORB_SLAM/Settings/Settings.h:72:8: note: previous declaration 'bool MORB_SLAM::Settings::readParameter(const cv::FileStorage&, const string&, bool&, bool)'
   72 |   bool readParameter<bool>(const cv::FileStorage& settings, const std::string& name, bool& found, const bool required) {
      |        ^~~~~~~~~~~~~~~~~~~
/MORB_SLAM/include/MORB_SLAM/Settings/Settings.h:115:13: error: explicit specialization in non-namespace scope 'class MORB_SLAM::Settings'
  115 |   template <>
      |             ^
/MORB_SLAM/include/MORB_SLAM/Settings/Settings.h:116:7: error: template-id 'readParameter<int>' in declaration of primary template
  116 |   int readParameter<int>(const cv::FileStorage& settings, const std::string& name, bool& found, const bool required) {
      |       ^~~~~~~~~~~~~~~~~~
/MORB_SLAM/include/MORB_SLAM/Settings/Settings.h:116:7: error: 'int MORB_SLAM::Settings::readParameter(const cv::FileStorage&, const string&, bool&, bool)' cannot be overloaded with 'bool MORB_SLAM::Settings::readParameter(const cv::FileStorage&, const string&, bool&, bool)'
/MORB_SLAM/include/MORB_SLAM/Settings/Settings.h:72:8: note: previous declaration 'bool MORB_SLAM::Settings::readParameter(const cv::FileStorage&, const string&, bool&, bool)'
   72 |   bool readParameter<bool>(const cv::FileStorage& settings, const std::string& name, bool& found, const bool required) {
      |        ^~~~~~~~~~~~~~~~~~~
/MORB_SLAM/include/MORB_SLAM/Settings/Settings.h:136:13: error: explicit specialization in non-namespace scope 'class MORB_SLAM::Settings'
  136 |   template <>

```

I added the header guard to fix a problem with a specific version of boost (1.74) to get around this error:

```
-- Build files have been written to: /MORB_SLAM/build
[0/2] Re-checking globbed directories...
[1/94] Building CXX object CMakeFiles/MORB_SLAM.dir/src/Camera.cpp.o
[2/94] Building CXX object CMakeFiles/MORB_SLAM.dir/src/Converter.cc.o
[3/94] Building CXX object CMakeFiles/MORB_SLAM.dir/src/Atlas.cc.o
[4/94] Building CXX object CMakeFiles/MORB_SLAM.dir/src/Exceptions.cpp.o
[5/94] Building CXX object CMakeFiles/MORB_SLAM.dir/src/FrameDrawer.cc.o
[6/94] Building CXX object CMakeFiles/MORB_SLAM.dir/src/Frame.cc.o
[7/94] Building CXX object CMakeFiles/MORB_SLAM.dir/src/G2oTypes.cc.o
[8/94] Building CXX object CMakeFiles/MORB_SLAM.dir/src/ImprovedTypes.cpp.o
[9/94] Building CXX object CMakeFiles/MORB_SLAM.dir/src/GeometricTools.cc.o
[10/94] Building CXX object CMakeFiles/MORB_SLAM.dir/src/KeyFrameDatabase.cc.o
FAILED: CMakeFiles/MORB_SLAM.dir/src/KeyFrameDatabase.cc.o 
/usr/bin/c++ -DBOOST_ALL_NO_LIB -DBOOST_REGEX_DYN_LINK -DBOOST_SERIALIZATION_DYN_LINK -DHAVE_EIGEN -DHAVE_GLEW -DHAVE_PYTHON -DMORB_SLAM_EXPORTS -DPANGO_DEFAULT_WIN_URI=\"x11\" -D_LINUX_ -I/MORB_SLAM/include -I/MORB_SLAM/Thirdparty/DBoW2 -I/MORB_SLAM/Thirdparty/g2o -I/MORB_SLAM/Thirdparty/Sophus -isystem /usr/include/opencv4 -isystem /usr/include/eigen3 -gdwarf-4 -fdiagnostics-color=always -O3 -DNDEBUG -fPIC -std=gnu++20 -MD -MT CMakeFiles/MORB_SLAM.dir/src/KeyFrameDatabase.cc.o -MF CMakeFiles/MORB_SLAM.dir/src/KeyFrameDatabase.cc.o.d -o CMakeFiles/MORB_SLAM.dir/src/KeyFrameDatabase.cc.o -c /MORB_SLAM/src/KeyFrameDatabase.cc
In file included from /MORB_SLAM/include/MORB_SLAM/KeyFrameDatabase.h:25,
                 from /MORB_SLAM/src/KeyFrameDatabase.cc:22:
/usr/include/boost/serialization/list.hpp: In function 'void boost::serialization::load(Archive&, std::__cxx11::list<_ValT, _Allocator>&, unsigned int)':
/usr/include/boost/serialization/list.hpp:53:33: error: 'library_version_type' in namespace 'boost::serialization' does not name a type; did you mean 'item_version_type'?
   53 |     const boost::serialization::library_version_type library_version(
      |                                 ^~~~~~~~~~~~~~~~~~~~
      |                                 item_version_type
/usr/include/boost/serialization/list.hpp:60:30: error: 'library_version_type' is not a member of 'boost::serialization'; did you mean 'item_version_type'?
   60 |     if(boost::serialization::library_version_type(3) < library_version){
      |                              ^~~~~~~~~~~~~~~~~~~~
      |                              item_version_type
/usr/include/boost/serialization/list.hpp:60:56: error: 'library_version' was not declared in this scope
   60 |     if(boost::serialization::library_version_type(3) < library_version){
      |                                                        ^~~~~~~~~~~~~~~
[11/94] Building CXX object CMakeFiles/MORB_SLAM.dir/src/KeyFrame.cc.o
ninja: build stopped: subcommand failed.
ERROR: process "/bin/sh -c echo \"Extracting ORB vocabulary...\"     && mkdir ${MORB_SLAM_VOCABULARY_DIR}     && tar -xvf ${MORB_SLAM_ROOT_DIR}/Vocabulary/ORBvoc.txt.tar.gz -C ${MORB_SLAM_VOCABULARY_DIR}     && cd ${MORB_SLAM_ROOT_DIR}     && rm src/ExternalMapViewer.cc     && sed -i '/target_link_libraries(.*ixwebsocket::ixwebsocket.*)/d' CMakeLists.txt     && mkdir build     && cd build     && cmake -G Ninja ..     && ninja -j2     && ninja install     && ldconfig     && rm -rf ${MORB_SLAM_ROOT_DIR}" did not complete successfully: exit code: 1
------
 > [15/16] RUN echo "Extracting ORB vocabulary..."     && mkdir /MORB_SLAM_VOCABULARY     && tar -xvf /MORB_SLAM/Vocabulary/ORBvoc.txt.tar.gz -C /MORB_SLAM_VOCABULARY     && cd /MORB_SLAM     && rm src/ExternalMapViewer.cc     && sed -i '/target_link_libraries(.*ixwebsocket::ixwebsocket.*)/d' CMakeLists.txt     && mkdir build     && cd build     && cmake -G Ninja ..     && ninja -j2     && ninja install     && ldconfig     && rm -rf /MORB_SLAM:
29.64       |                                 item_version_type
29.64 /usr/include/boost/serialization/list.hpp:60:30: error: 'library_version_type' is not a member of 'boost::serialization'; did you mean 'item_version_type'?
29.64    60 |     if(boost::serialization::library_version_type(3) < library_version){
29.64       |                              ^~~~~~~~~~~~~~~~~~~~
29.64       |                              item_version_type
29.64 /usr/include/boost/serialization/list.hpp:60:56: error: 'library_version' was not declared in this scope
29.64    60 |     if(boost::serialization::library_version_type(3) < library_version){
29.64       |                                                        ^~~~~~~~~~~~~~~
32.57 [11/94] Building CXX object CMakeFiles/MORB_SLAM.dir/src/KeyFrame.cc.o
32.57 ninja: build stopped: subcommand failed.
```

Notably boost version 1.74 is the one shipped by ubuntu 22.04 